### PR TITLE
Support passing configuration through .eslintrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Inside your `.eslintrc` file, pass this resolver to `eslint-plugin-import`:
 ```
 
 And see [babel-plugin-root-import] to know how to configure your prefix/suffix. 
-Configuration will be parsed down from `.babelrc` file 
+Configuration will be parsed down from `.babelrc` file
 
 ### Example
 
@@ -33,6 +33,24 @@ Configuration will be parsed down from `.babelrc` file
   "settings": {
     "import/resolver": {
       "babel-plugin-root-import": {}
+    }
+  }
+}
+```
+
+Or if you don't use `.babelrc` and keep your babel configuration in, say, webpack
+config you can pass those options to resolver directly through `.eslintrc` file:
+
+```json
+{
+  "extends": "airbnb",
+  "rules": {},
+  "settings": {
+    "import/resolver": {
+      "babel-plugin-root-import": {
+        "rootPathPrefix": "@",
+        "rootPathSuffix": "src/js"
+      }
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,35 @@ test('Resolves files required from a file deeper in the tree', (t) => {
     t.end();
 });
 
+test('Supports passing aliases directly through eslint import/resolver settings', (t) => {
+    t.deepEqual(
+        resolve('#/file', __filename, [
+            { rootPathPrefix: '@', rootPathSuffix: 'modules' },
+            { rootPathPrefix: '#', rootPathSuffix: 'modules/anotherpath' },
+        ]),
+        expectResolvedTo('modules/anotherpath/file.js'),
+        'Array of objects w/ rootPathPrefix and rootPathSuffix'
+    );
+
+    t.deepEqual(
+        resolve('~/file', __filename, {
+            rootPathSuffix: 'modules/anotherpath'
+        }),
+        expectResolvedTo('modules/anotherpath/file.js'),
+        'Object, only suffix specified'
+    );
+
+    t.deepEqual(
+        resolve('!/modules/file', __filename, {
+            rootPathPrefix: '!'
+        }),
+        expectResolvedTo('modules/file.js'),
+        'Object, only prefix specified'
+    );
+
+    t.end();
+});
+
 test('Correctly resolves default prefix (~/) when no configuration provided', (t) => {
     const result = resolve('~/modules/file', relativeToTestDir('./some/other/file.js'), {}, '.babelrcNoConf');
     const result2 = resolve('~/modules/file', relativeToTestDir('./some/other/file.js'), {}, '.babelrcNoConfArray');


### PR DESCRIPTION
Allowing alias settings to be passed directly through eslint configuration, avoiding `.babelrc` parsing completely